### PR TITLE
Updated getTable() function to work with linux os as well

### DIFF
--- a/__mocks__/child_process.ts
+++ b/__mocks__/child_process.ts
@@ -33,11 +33,22 @@ const arpTableMac = `? (192.168.137.255) at ff-ff-ff-ff-ff-ff on en9 ifscope [et
   ? (239.255.255.250) at 01-00-5e-7f-ff-fa on en9 ifscope [ethernet]
   ? (255.255.255.255) at ff-ff-ff-ff-ff-ff on en9 ifscope [ethernet]`
 
+const arpTableLinux = `? (192.168.0.14) at 1s:21:f3:f1:fe:f2 [ether] on wlan0
+? (192.168.0.13) at 01:00:5e:7f:ff:fa [ether] on wlan0
+? (192.168.0.3) at ff:ff:ff:ff:ff:ff [ether] on wlan0
+? (192.168.0.2) at 01:00:5e:00:00:fb [ether] on wlan0
+? (192.168.0.7) at 01:00:5e:00:00:16 [ether] on wlan0
+? (192.168.0.6) at 01:00:5e:00:00:02 [ether] on wlan0
+? (192.168.0.5) at 01:00:5e:7f:ff:fa [ether] on wlan0`
+
 export function exec(cmd: string, cb: (err: Error | undefined, stdout: string) => void) {
   if (cmd !== 'arp -a') cb(Error('Unknown command'), 'unknown command')
 
-  if (process.platform.substring(0, 3) === 'win') {
+  let platform = process.platform.substring(0, 3);
+  if (platform === 'win') {
     cb(undefined, arpTableWin)
+  } else if(platform === 'lin') {
+    cb(undefined, arpTableLinux)
   } else {
     cb(undefined, arpTableMac)
   }

--- a/__test__/arp-lookup-lin.test.ts
+++ b/__test__/arp-lookup-lin.test.ts
@@ -1,0 +1,20 @@
+jest.mock('child_process')
+
+import arp from '../src/index'
+
+describe('On a Linux environment', () => {
+  Object.defineProperty(process, 'platform', {
+    value: 'linux'
+  })
+  test('Arp table is parsed', async done => {
+    await expect(arp.getTable()).resolves.toEqual([
+      { ip: '192.168.0.13', mac: '01:00:5e:7f:ff:fa', type: 'unknown', vendor: ''},
+      { ip: '192.168.0.3', mac: 'ff:ff:ff:ff:ff:ff', type: 'unknown', vendor: ''},
+      { ip: '192.168.0.2', mac: '01:00:5e:00:00:fb', type: 'unknown', vendor: ''},
+      { ip: '192.168.0.7', mac: '01:00:5e:00:00:16', type: 'unknown', vendor: ''},
+      { ip: '192.168.0.6', mac: '01:00:5e:00:00:02', type: 'unknown', vendor: ''},
+      { ip: '192.168.0.5', mac: '01:00:5e:7f:ff:fa', type: 'unknown', vendor: ''}
+    ])
+    done()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,8 +142,8 @@ export function getTable(): Promise<IArpTable> {
             .replace(/\s+/g, ' ')
             .split(' ') as [string, string, IArpTableRow['type']]
         } else {
-          // Parse the rows as they are returned on unix (Mac) systems
-          const match = /.*\((.*?)\) at (.*) on/g.exec(row)
+          // Parse the rows as they are returned on unix (Mac or Linux) systems
+          const match = /.*\((.*?)\) at (.{0,17}) (?:\[ether\]|on)/g.exec(row)
           if (match && match.length === 3) {
             ip = match[1]
             mac = fixMAC(match[2])


### PR DESCRIPTION
I noticed that the getTable() function did not correctly parse the output of `arp -a` on linux os, so I decided to fix it for my own needs and made a PR. Hope this is useful!